### PR TITLE
Fixed

### DIFF
--- a/public/chat.js
+++ b/public/chat.js
@@ -30,9 +30,12 @@ const autoscroll = () => {
   //Toatal height of message container
   const containerHeight = $messageContainer.scrollHeight;
   //How far i have scrolled
-  const scrollOffset = Math.trunc($messageContainer.scrollTop) + VisibleHeight;
+  const scrollOffset = $messageContainer.scrollTop + VisibleHeight;
+  console.log("container height", containerHeight);
+  console.log("scroll offset", scrollOffset);
+  console.log("added scroll offset", scrollOffset + 100);
 
-  if (containerHeight - newMessageHeight <= scrollOffset) {
+  if (containerHeight <= scrollOffset + 100) {
     $messageContainer.scrollTop = $messageContainer.scrollHeight;
   }
 };

--- a/public/chat.js
+++ b/public/chat.js
@@ -31,9 +31,6 @@ const autoscroll = () => {
   const containerHeight = $messageContainer.scrollHeight;
   //How far i have scrolled
   const scrollOffset = $messageContainer.scrollTop + VisibleHeight;
-  console.log("container height", containerHeight);
-  console.log("scroll offset", scrollOffset);
-  console.log("added scroll offset", scrollOffset + 100);
 
   if (containerHeight <= scrollOffset + 100) {
     $messageContainer.scrollTop = $messageContainer.scrollHeight;


### PR DESCRIPTION
I added 100 to the scrollOffset so that it will always be greater than containerHeight when the user is at the bottom but smaller when the user is reading up the chats. 

if (containerHeight - newMessageHeight <= scrollOffset + 100) {
    $messageContainer.scrollTop = $messageContainer.scrollHeight;
  } 
  
  Prolly you are intrested in the message height, this works also.
  
  A little bug is it scrolls down when the user is like a chat up (the user just scrolls u a little)